### PR TITLE
PHP 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 4. Copy resources (css, js, etc)
 
-        $ cp templates/res/* static/
+        $ cp -r templates/res/* static/
 
 5. Point your browser to static/ directory
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 1. php5-cli
 2. php5-mysql
-3. PEAR's HTML\_BBCodeParser (http://pear.php.net/package/HTML_BBCodeParser)
+3. PEAR's HTML\_BBCodeParser (http://pear.php.net/package/HTML_BBCodeParser2)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-Requirements
-============
+# phpbb3-static
+
+## Requirements
 
 1. php5-cli
 2. php5-mysql
-3. PEAR's HTML_BBCodeParser (http://pear.php.net/package/HTML_BBCodeParser)
+3. PEAR's HTML\_BBCodeParser (http://pear.php.net/package/HTML_BBCodeParser)
 
-Usage
-=====
+## Usage
 
 1. Edit config.php. Set your database configuration
+
 2. Create static/ directory
 
-   $ mkdir static
+        $ mkdir static
 
 3. Run convert.php script
 
-   $ php convert.php
+        $ php convert.php
 
 4. Copy resources (css, js, etc)
 
-   $ cp templates/res/* static/
+        $ cp templates/res/* static/
 
 5. Point your browser to static/ directory
 
 6. That's all :)
-

--- a/common.php
+++ b/common.php
@@ -1,10 +1,10 @@
 <?php
 
-include('HTML/BBCodeParser.php');
+include('HTML/BBCodeParser2.php');
 $bbopt = array(
 	'filters' => array('Basic', 'Email', 'Extended', 'Images', 'Links', 'Lists')
 );
-$bb = new HTML_BBCodeParser($bbopt);
+$bb = new HTML_BBCodeParser2($bbopt);
 
 function template_print($var, $template) {
 	extract($var);

--- a/common.php
+++ b/common.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 include('HTML/BBCodeParser.php');
 $bbopt = array(

--- a/common.php
+++ b/common.php
@@ -30,7 +30,7 @@ function write_content($file, $content) {
 	$target = $target_dir . '/' . $file;
 	$dir = dirname($target);
 
-	if (!is_dir($dir)) {
+	if (!is_dir($dir) && !is_link($dir)) {
 		mkdir($dir, 0755);
 	}
 

--- a/config.php
+++ b/config.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 $db_host = 'localhost';
 $db_user = 'phpbb';

--- a/convert.php
+++ b/convert.php
@@ -97,7 +97,7 @@ function generate_topics() {
 				'username'   => $row['username'],
 				'post_text'  => $row['post_text'],
 				'post_time'  => $row['post_time'],
-				'bbcde_uid'  => $row['bbcode_uid']
+				'bbcode_uid'  => $row['bbcode_uid'],
 			);
 		}
 		

--- a/convert.php
+++ b/convert.php
@@ -235,7 +235,11 @@ $topics = array();
 $forums_tree = array();
 $forums_top = array();
 
-generate_main();
-generate_forums();
-generate_topics();
-
+try {
+  generate_main();
+  generate_forums();
+  generate_topics();
+} catch(PDOException $ex) {
+  echo "An Error occured! " . $ex->getMessage();
+  throw $ex;
+}

--- a/convert.php
+++ b/convert.php
@@ -98,6 +98,7 @@ function generate_topics() {
 				'post_text'  => $row['post_text'],
 				'post_time'  => $row['post_time'],
 				'bbcode_uid'  => $row['bbcode_uid'],
+				'post_id'  => $row['post_id'],
 			);
 		}
 		

--- a/convert.php
+++ b/convert.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 require_once('config.php');
 require_once('common.php');

--- a/templates/forum.tpl.php
+++ b/templates/forum.tpl.php
@@ -24,7 +24,7 @@
 </tr>
 </thead>
 <tbody>
-<?
+<?php
 
 	foreach ($list as $tid) {
 
@@ -40,7 +40,7 @@
 	<td class="ta"><?=$ta;?></td>
 	<td class="dt"><?=$dt;?></td>
 </tr>
-<?
+<?php
 
 	}
 

--- a/templates/main.tpl.php
+++ b/templates/main.tpl.php
@@ -12,7 +12,7 @@
 	<th class="tt">Topics</th>
 	<th class="tc">Posts</th>
 </tr>
-<?
+<?php
 
 while (list($cid, $cat) = each($categories)) {
 
@@ -22,7 +22,7 @@ while (list($cid, $cat) = each($categories)) {
 <tr>
 	<th colspan="3" class="cat"><?=$ctitle;?></th>
 </tr>
-<?
+<?php
 
 	foreach ($cat['forums'] as $fid) {
 
@@ -36,7 +36,7 @@ while (list($cid, $cat) = each($categories)) {
 	<td class="tt"><?=$tt;?></td>
 	<td class="tp"><?=$tp;?></td>
 </tr>
-<?
+<?php
 
 	}
 }

--- a/templates/topic.tpl.php
+++ b/templates/topic.tpl.php
@@ -35,7 +35,7 @@ global $bb;
 		$html = nl2br($bb->qParse($text));
 
 ?>
-<div class="post <?=$oe;?>">
+<div class="post">
 	<div class="info">
 		<p class="poster"><?=$user;?></p>
 		<p class="dt"><?=$dt;?></p>

--- a/templates/topic.tpl.php
+++ b/templates/topic.tpl.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 global $bb;
 
@@ -20,7 +20,7 @@ global $bb;
 	<a href="<?=$url;?>"><?=$url;?></a>
 </p></div>
 
-<?
+<?php
 
 	foreach ($posts as $post) {
 
@@ -46,7 +46,7 @@ global $bb;
 	<!-- END MESSAGE -->
 	</div>
 </div>
-<?
+<?php
 
 	}
 

--- a/templates/topic.tpl.php
+++ b/templates/topic.tpl.php
@@ -29,13 +29,14 @@ global $bb;
 		$time = $post['post_time'];
 		$dt = date('d-m-Y H:i:s', $time);
 		$bid = $post['bbcode_uid'];
+		$post_id = $post['post_id'];
 
 		$text = str_replace(':' . $bid, '', $text);
 		$text = preg_replace('/\[(\/?)code:\d*\]/', '[\1code]', $text);
 		$html = nl2br($bb->qParse($text));
 
 ?>
-<div class="post">
+<div class="post" id="p<?=$post_id?>">
 	<div class="info">
 		<p class="poster"><?=$user;?></p>
 		<p class="dt"><?=$dt;?></p>


### PR DESCRIPTION
Hi!

I've made a couple edits to run the converter with PHP 7.0. This pull requests changes a number of things, but each change is in a dedicated commit.

- Convert README to Markdown
- Use long opening tag (<?php … >) so it works out of the box, otherwise "php convert.php" just prints the code to the screen
- Use HTML_BBCodeParser2 (which is the current variant of the bbcode parsing library as of 2016)
- Tolerate a symlink 'static', not only a directory (I wanted to run under ~/src/… but output to ~/public_html/… using a symlink)
- Use PDO for MySQL queries, because PHP 7.0 no longer has the mysql_* functions.
- Minor fixes in templates
- Wrap top-level function calls in a try-catch block, which allows printing a helpful error message.

I hope that it's okay to bundle them all together in one pull request.

Maciej
