### PR TITLE
Changes to be compatible with phpBB 3.1/3.2

### DIFF
--- a/config.php-example
+++ b/config.php-example
@@ -37,5 +37,6 @@ define('PHPBB3', 3);
 define('PHPBB2', 2);
 
 $phpbb_version = PHPBB3;
+$phpbb3_minor_version = 0; // 0, 1 or 2
 
 ?>

--- a/extract.php
+++ b/extract.php
@@ -133,7 +133,6 @@ SQL
           //   var_dump($caller->errors());
           // }
           $xpath = new DOMXpath($doc);
-
           foreach($xpath->query("//div[contains(@class, 'post') and contains(@id, 'p')]") as $div) {
             $id = $div->getAttribute('id');
             $textNodes = $xpath->query("//div[@id='{$id}']//div[@class='content']");
@@ -230,8 +229,8 @@ function get_forums_and_topics($phpbb_version, $db, $db_prefix, $extracted) {
   }
   else if ($phpbb_version == PHPBB3) {
     //FIXME: fix ordering
-    $res = $db->query("SELECT forum_id, forum_name, forum_posts, forum_topics FROM {$db_prefix}forums WHERE parent_id<>0 ORDER BY left_id;");
-  }
+    $res = $db->query("SELECT forum_id, forum_name, forum_posts_approved, forum_topics_approved FROM {$db_prefix}forums WHERE parent_id<>0 ORDER BY left_id;");
+}
 
   $categories = $extracted['categories'];
   foreach ($res as $row) {
@@ -246,8 +245,8 @@ function get_forums_and_topics($phpbb_version, $db, $db_prefix, $extracted) {
 
     $forums[$fid] = array(
       'title'   => $row['forum_name'],
-      'nposts'  => $row['forum_posts'],
-      'ntopics' => $row['forum_topics'],
+      'nposts'  => $row['forum_posts_approved'],
+      'ntopics' => $row['forum_topics_approved'],
       'topics'  => array()
     );
 
@@ -261,7 +260,7 @@ SELECT
   t.topic_id,
   t.topic_title,
   t.topic_time,
-  t.topic_replies,
+  t.topic_posts_approved,
   u.username
 FROM
   {$db_prefix}topics t
@@ -285,7 +284,7 @@ SQL
       'fid'     => $fid,
       'title'   => $row['topic_title'],
       'time'    => $row['topic_time'],
-      'replies' => $row['topic_replies'],
+      'replies' => $row['topic_posts_approved'],
       'author'  => $row['username'],
       'lastmod' => gmdate('Y-m-d\TH:i:s\Z', $row['topic_time']),
     );

--- a/extract.php
+++ b/extract.php
@@ -229,7 +229,13 @@ function get_forums_and_topics($phpbb_version, $db, $db_prefix, $extracted) {
   }
   else if ($phpbb_version == PHPBB3) {
     //FIXME: fix ordering
-    $res = $db->query("SELECT forum_id, forum_name, forum_posts_approved, forum_topics_approved FROM {$db_prefix}forums WHERE parent_id<>0 ORDER BY left_id;");
+    if($phpbb3_minor_version == 0) {
+        $res = $db->query("SELECT forum_id, forum_name, forum_posts, forum_topics FROM {$db_prefix}forums WHERE parent_id<>0 ORDER BY left_id;");
+    } elseif ($phpbb3_minor_version == 1 || $phpbb3_minor_version == 2) {
+        $res = $db->query("SELECT forum_id, forum_name, forum_posts_approved, forum_topics_approved FROM {$db_prefix}forums WHERE parent_id<>0 ORDER BY left_id;");
+    } else {
+        die('Unknown PHPBB minor version');
+    }
 }
 
   $categories = $extracted['categories'];
@@ -243,36 +249,71 @@ function get_forums_and_topics($phpbb_version, $db, $db_prefix, $extracted) {
     $forums_tree = $extracted['forums_tree'];
     $cat_id = $forums_tree[$fid]['cat_id'];
 
-    $forums[$fid] = array(
-      'title'   => $row['forum_name'],
-      'nposts'  => $row['forum_posts_approved'],
-      'ntopics' => $row['forum_topics_approved'],
-      'topics'  => array()
-    );
+    if($phpbb3_minor_version == 0) {
+        $forums[$fid] = array(
+          'title'   => $row['forum_name'],
+          'nposts'  => $row['forum_posts'],
+          'ntopics' => $row['forum_topics'],
+          'topics'  => array()
+        );
+    } elseif ($phpbb3_minor_version == 1 || $phpbb3_minor_version == 2) {
+        $forums[$fid] = array(
+          'title'   => $row['forum_name'],
+          'nposts'  => $row['forum_posts_approved'],
+          'ntopics' => $row['forum_topics_approved'],
+          'topics'  => array()
+        );
+    } else {
+        die('Unknown PHPBB minor version');
+    }
 
     $categories[$cat_id]['forums'][] = $fid;
   }
 
   // Get topics
-  $res = $db->query(<<<SQL
-SELECT
-  t.forum_id,
-  t.topic_id,
-  t.topic_title,
-  t.topic_time,
-  t.topic_posts_approved,
-  u.username
-FROM
-  {$db_prefix}topics t
-  LEFT JOIN {$db_prefix}users u ON t.topic_poster=u.user_id
-WHERE
-  t.topic_moved_id = 0
-ORDER BY
-  t.topic_time DESC
--- LIMIT 100 -- uncomment in development for faster runs
-;
-SQL
-);
+if($phpbb3_minor_version == 0) {
+    $res = $db->query(<<<SQL
+    SELECT
+      t.forum_id,
+      t.topic_id,
+      t.topic_title,
+      t.topic_time,
+      t.topic_replies,
+      u.username
+    FROM
+      {$db_prefix}topics t
+      LEFT JOIN {$db_prefix}users u ON t.topic_poster=u.user_id
+    WHERE
+      t.topic_moved_id = 0
+    ORDER BY
+      t.topic_time DESC
+    -- LIMIT 100 -- uncomment in development for faster runs
+    ;
+    SQL
+    );
+} elseif ($phpbb3_minor_version == 1 || $phpbb3_minor_version == 2) {
+    $res = $db->query(<<<SQL
+    SELECT
+      t.forum_id,
+      t.topic_id,
+      t.topic_title,
+      t.topic_time,
+      t.topic_posts_approved,
+      u.username
+    FROM
+      {$db_prefix}topics t
+      LEFT JOIN {$db_prefix}users u ON t.topic_poster=u.user_id
+    WHERE
+      t.topic_moved_id = 0
+    ORDER BY
+      t.topic_time DESC
+    -- LIMIT 100 -- uncomment in development for faster runs
+    ;
+    SQL
+    );
+} else {
+    die('Unknown PHPBB minor version');
+}
   foreach ($res as $row) {
     $fid = $row['forum_id'];
 
@@ -280,14 +321,27 @@ SQL
       continue;
     }
 
-    $topics[$row['topic_id']] = array(
-      'fid'     => $fid,
-      'title'   => $row['topic_title'],
-      'time'    => $row['topic_time'],
-      'replies' => $row['topic_posts_approved'],
-      'author'  => $row['username'],
-      'lastmod' => gmdate('Y-m-d\TH:i:s\Z', $row['topic_time']),
-    );
+    if($phpbb3_minor_version == 0) {
+        $topics[$row['topic_id']] = array(
+          'fid'     => $fid,
+          'title'   => $row['topic_title'],
+          'time'    => $row['topic_time'],
+          'replies' => $row['topic_replies'],
+          'author'  => $row['username'],
+          'lastmod' => gmdate('Y-m-d\TH:i:s\Z', $row['topic_time']),
+        );
+    } elseif ($phpbb3_minor_version == 1 || $phpbb3_minor_version == 2) {
+        $topics[$row['topic_id']] = array(
+          'fid'     => $fid,
+          'title'   => $row['topic_title'],
+          'time'    => $row['topic_time'],
+          'replies' => $row['topic_posts_approved'],
+          'author'  => $row['username'],
+          'lastmod' => gmdate('Y-m-d\TH:i:s\Z', $row['topic_time']),
+        );
+    }  else {
+        die('Unknown PHPBB minor version');
+    }
     $forums[$fid]['topics'][] = $row['topic_id'];
   }
 

--- a/templates/forum.tpl.php
+++ b/templates/forum.tpl.php
@@ -33,7 +33,7 @@
 
 		$title = $topics[$tid]['title'];
 		$slug = slug($title);
-		$tp = $topics[$tid]['replies'] + 1;
+		$tp = $topics[$tid]['replies'];
 		$ta = $topics[$tid]['author'];
 
 		$dt = date('d-m-Y H:i:s', $topics[$tid]['time']);

--- a/templates/forum.tpl.php
+++ b/templates/forum.tpl.php
@@ -33,7 +33,13 @@
 
 		$title = $topics[$tid]['title'];
 		$slug = slug($title);
-		$tp = $topics[$tid]['replies'];
+		if($phpbb3_minor_version == 0) {
+			$tp = $topics[$tid]['replies'] + 1;
+		} elseif ($phpbb3_minor_version == 1 || $phpbb3_minor_version == 2) {
+			$tp = $topics[$tid]['replies'];
+		} else {
+			die('Unknown PHPBB minor version');
+		}
 		$ta = $topics[$tid]['author'];
 
 		$dt = date('d-m-Y H:i:s', $topics[$tid]['time']);


### PR DESCRIPTION
In 3.1 they changed two things:

- Post/topic count was split into multiple columns depending on status
- Post count include original post

Thus some queries needed to be changed and the template no longer needs to add 1 to the post count.